### PR TITLE
Use class syntax in JwtVerifyError

### DIFF
--- a/src/jwtverifyerror.js
+++ b/src/jwtverifyerror.js
@@ -1,13 +1,8 @@
-// @ts-check
-'use strict'
-
-function JwtVerifyError(message, innerError) {
-  this.name = 'JwtVerifyError'
-  this.message = message
-  this.stack = new Error().stack
-  this.innerError = innerError || null
+class JwtVerifyError extends Error {
+  constructor(message, innerError = null) {
+    super(message)
+    this.innerError = innerError
+  }
 }
-JwtVerifyError.prototype = Object.create(Error.prototype)
-JwtVerifyError.prototype.constructor = JwtVerifyError
 
 module.exports = JwtVerifyError


### PR DESCRIPTION
Turn JwtVerifyError into a class to match the type definition.